### PR TITLE
Add full Javadoc coverage and publishJavadocToNexus task

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,7 @@
+import java.net.HttpURLConnection
+import java.net.URI
+import java.util.Base64
+
 group = "com.github.angeschossen"
 version = "1.1.23"
 description = "PluginFrameworkAPI"
@@ -41,17 +45,78 @@ dependencies {
 }
 
 java {
+    toolchain.languageVersion.set(JavaLanguageVersion.of(21))
     withSourcesJar()
     withJavadocJar()
-}
-
-java {
-    toolchain.languageVersion.set(JavaLanguageVersion.of(17))
 }
 
 tasks {
     jar {
         archiveFileName.set("PluginFrameworkAPI.jar")
+    }
+
+    withType<PublishToMavenRepository>().configureEach {
+        doLast {
+            val repoName = repository.url.toString().trimEnd('/').substringAfterLast('/')
+            println("Published ${publication.groupId}:${publication.artifactId}:${publication.version}")
+            println("Browse at: https://nexus.incredibleplugins.com/#browse/browse:$repoName")
+        }
+    }
+}
+
+tasks.register("publishJavadocToNexus") {
+    dependsOn("javadocJar")
+    description = "Extracts the javadoc jar and uploads its contents to the Nexus raw repository."
+    group = "publishing"
+
+    doLast {
+        val javadocJar = tasks.named<Jar>("javadocJar").get().archiveFile.get().asFile
+        val extractDir = layout.buildDirectory.dir("javadoc-site").get().asFile
+
+        // Extract javadoc jar into build/javadoc-site
+        if (extractDir.exists()) extractDir.deleteRecursively()
+        copy {
+            from(zipTree(javadocJar))
+            into(extractDir)
+        }
+
+        val username = (project.findProperty("nexusUsername") as String?
+            ?: System.getenv("NEXUS_USERNAME")
+            ?: error("nexusUsername not set"))
+        val password = (project.findProperty("nexusPassword") as String?
+            ?: System.getenv("NEXUS_PASSWORD")
+            ?: error("nexusPassword not set"))
+        val credentials = Base64.getEncoder()
+            .encodeToString("$username:$password".toByteArray())
+
+        val baseUrl = "https://nexus.incredibleplugins.com/repository/plugin-javadoc-public" +
+                "/${project.group.toString().replace('.', '/')}" +
+                "/${project.description}/${project.version}"
+
+        val latestUrl = "https://nexus.incredibleplugins.com/repository/plugin-javadoc-public" +
+                "/${project.group.toString().replace('.', '/')}" +
+                "/${project.description}/latest"
+
+        extractDir.walkTopDown().filter { it.isFile }.forEach { file ->
+            val relativePath = file.relativeTo(extractDir).path.replace('\\', '/')
+            for (uploadUrl in listOf(baseUrl, latestUrl)) {
+                val connection = URI("$uploadUrl/$relativePath").toURL()
+                    .openConnection() as HttpURLConnection
+                connection.requestMethod = "PUT"
+                connection.doOutput = true
+                connection.setRequestProperty("Authorization", "Basic $credentials")
+                connection.setRequestProperty("Content-Type", "application/octet-stream")
+                file.inputStream().use { it.copyTo(connection.outputStream) }
+                val code = connection.responseCode
+                if (code !in 200..299) {
+                    throw GradleException("Failed to upload $relativePath to $uploadUrl — HTTP $code: ${connection.responseMessage}")
+                }
+            }
+            println("Uploaded: $relativePath")
+        }
+
+        println("Javadoc published to $baseUrl/index.html")
+        println("Latest javadoc at $latestUrl/index.html")
     }
 }
 
@@ -63,6 +128,23 @@ publishing {
             version = project.version.toString()
 
             from(components["java"])
+        }
+    }
+
+    repositories {
+        maven {
+            name = "nexus"
+            val isSnapshot = version.toString().endsWith("-SNAPSHOT")
+            url = uri(
+                if (isSnapshot)
+                    "https://nexus.incredibleplugins.com/repository/maven-snapshots/"
+                else
+                    "https://nexus.incredibleplugins.com/repository/plugin-maven-releases/"
+            )
+            credentials {
+                username = project.findProperty("nexusUsername") as String? ?: System.getenv("NEXUS_USERNAME")
+                password = project.findProperty("nexusPassword") as String? ?: System.getenv("NEXUS_PASSWORD")
+            }
         }
     }
 }

--- a/src/main/java/com/github/angeschossen/pluginframework/api/blockutil/impl/BlockCoordinate.java
+++ b/src/main/java/com/github/angeschossen/pluginframework/api/blockutil/impl/BlockCoordinate.java
@@ -3,51 +3,119 @@ package com.github.angeschossen.pluginframework.api.blockutil.impl;
 
 import org.bukkit.Location;
 
+/**
+ * Mutable integer block coordinate holding x, y, and z values.
+ */
 public class BlockCoordinate {
-    public int x, y, z;
+    /** The x-coordinate of the block. */
+    public int x;
+    /** The y-coordinate of the block. */
+    public int y;
+    /** The z-coordinate of the block. */
+    public int z;
 
+    /**
+     * Creates a new coordinate with the given block coordinates.
+     *
+     * @param x the x-coordinate
+     * @param y the y-coordinate
+     * @param z the z-coordinate
+     */
     public BlockCoordinate(int x, int y, int z) {
         this.x = x;
         this.y = y;
         this.z = z;
     }
 
+    /**
+     * Returns the x-coordinate.
+     *
+     * @return the x-coordinate
+     */
     public int getX() {
         return x;
     }
 
+    /**
+     * Returns the y-coordinate.
+     *
+     * @return the y-coordinate
+     */
     public int getY() {
         return y;
     }
 
+    /**
+     * Returns the z-coordinate.
+     *
+     * @return the z-coordinate
+     */
     public int getZ() {
         return z;
     }
 
+    /**
+     * Returns the chunk x-coordinate derived from this block's x-coordinate.
+     *
+     * @return the chunk x-coordinate
+     */
     public int getChunkX() {
         return x >> 4;
     }
 
+    /**
+     * Returns the chunk z-coordinate derived from this block's z-coordinate.
+     *
+     * @return the chunk z-coordinate
+     */
     public int getChunkZ() {
         return z >> 4;
     }
 
+    /**
+     * Sets the x-coordinate.
+     *
+     * @param x the new x-coordinate
+     */
     public void setX(int x) {
         this.x = x;
     }
 
+    /**
+     * Sets the y-coordinate.
+     *
+     * @param y the new y-coordinate
+     */
     public void setY(int y) {
         this.y = y;
     }
 
+    /**
+     * Sets the z-coordinate.
+     *
+     * @param z the new z-coordinate
+     */
     public void setZ(int z) {
         this.z = z;
     }
 
+    /**
+     * Creates a new coordinate from the given Bukkit location.
+     *
+     * @param location the location to extract block coordinates from
+     */
     public BlockCoordinate(Location location) {
         this(location.getBlockX(), location.getBlockY(), location.getBlockZ());
     }
 
+    /**
+     * Checks whether this coordinate matches the given block coordinates.
+     *
+     * @param x the x-coordinate
+     * @param y the y-coordinate
+     * @param z the z-coordinate
+     * @return {@code true} if all three coordinates match
+     */
     public final boolean equals(int x, int y, int z) {
         return this.x == x && this.y == y && this.z == z;
     }

--- a/src/main/java/com/github/angeschossen/pluginframework/api/blockutil/impl/BlockKey.java
+++ b/src/main/java/com/github/angeschossen/pluginframework/api/blockutil/impl/BlockKey.java
@@ -6,10 +6,22 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.Objects;
 
+/**
+ * Immutable key identifying a block by its world and integer coordinates.
+ * Can be used as a map key to store per-block data.
+ */
 public class BlockKey implements com.github.angeschossen.pluginframework.api.blockutil.BlockKey {
     private final int x, y, z;
     private final World world;
 
+    /**
+     * Creates a new key for the given world and block coordinates.
+     *
+     * @param world the world containing the block
+     * @param x     the x-coordinate of the block
+     * @param y     the y-coordinate of the block
+     * @param z     the z-coordinate of the block
+     */
     public BlockKey(@NotNull World world, int x, int y, int z) {
         this.x = x;
         this.y = y;
@@ -17,11 +29,21 @@ public class BlockKey implements com.github.angeschossen.pluginframework.api.blo
         this.world = world;
     }
 
+    /**
+     * Creates a new key from the given Bukkit location.
+     *
+     * @param location the location whose block coordinates and world are used
+     */
     public BlockKey(@NotNull Location location) {
         this(Objects.requireNonNull(location.getWorld(), "world must not be null"), location.getBlockX(), location.getBlockY(), location.getBlockZ());
     }
 
 
+    /**
+     * Converts this key to a Bukkit {@link Location}.
+     *
+     * @return a location representing this block
+     */
     @NotNull
     public final Location toLocation() {
         return new Location(world, x, y, z);
@@ -37,6 +59,11 @@ public class BlockKey implements com.github.angeschossen.pluginframework.api.blo
         return z >> 4;
     }
 
+    /**
+     * Returns the world this block key belongs to.
+     *
+     * @return the world
+     */
     @NotNull
     public World getWorld() {
         return world;

--- a/src/main/java/com/github/angeschossen/pluginframework/api/blockutil/impl/BlockPosition.java
+++ b/src/main/java/com/github/angeschossen/pluginframework/api/blockutil/impl/BlockPosition.java
@@ -8,10 +8,27 @@ import org.bukkit.block.Block;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+/**
+ * Immutable block position consisting of a world and integer block coordinates.
+ */
 public class BlockPosition implements com.github.angeschossen.pluginframework.api.blockutil.BlockPosition {
+    /** The world this position belongs to. */
     public final World world;
-    public final int x, y, z;
+    /** The x-coordinate of the block. */
+    public final int x;
+    /** The y-coordinate of the block. */
+    public final int y;
+    /** The z-coordinate of the block. */
+    public final int z;
 
+    /**
+     * Creates a new position with the given world and block coordinates.
+     *
+     * @param world the world
+     * @param x     the x-coordinate
+     * @param y     the y-coordinate
+     * @param z     the z-coordinate
+     */
     public BlockPosition(World world, int x, int y, int z) {
         this.world = world;
         this.x = x;
@@ -19,15 +36,32 @@ public class BlockPosition implements com.github.angeschossen.pluginframework.ap
         this.z = z;
     }
 
+    /**
+     * Returns the block at this position in the world.
+     *
+     * @return the block at this position
+     */
     @NotNull
     public final Block getBlock() {
         return world.getBlockAt(x, y, z);
     }
 
+    /**
+     * Creates a new position from the given Bukkit location.
+     *
+     * @param location the location whose world and block coordinates are used
+     */
     public BlockPosition(Location location) {
         this(location.getWorld(), location.getBlockX(), location.getBlockY(), location.getBlockZ());
     }
 
+    /**
+     * Deserializes a {@code BlockPosition} from a JSON object.
+     * Returns {@code null} if the world specified in the JSON is not loaded.
+     *
+     * @param jsonObject the JSON object containing world, x, y, z fields
+     * @return the deserialized position, or {@code null} if the world is not loaded
+     */
     @Nullable
     public static BlockPosition fromJson(JsonObject jsonObject) {
         World world = Bukkit.getWorld(jsonObject.get("world").getAsString());
@@ -38,6 +72,15 @@ public class BlockPosition implements com.github.angeschossen.pluginframework.ap
         return new BlockPosition(world, jsonObject.get("x").getAsInt(), jsonObject.get("y").getAsInt(), jsonObject.get("z").getAsInt());
     }
 
+    /**
+     * Checks whether this position matches the given world and block coordinates.
+     *
+     * @param world the world to compare
+     * @param x     the x-coordinate
+     * @param y     the y-coordinate
+     * @param z     the z-coordinate
+     * @return {@code true} if world and all coordinates match
+     */
     public final boolean equals(World world, int x, int y, int z) {
         return this.world.equals(world) && this.x == x && this.y == y && this.z == z;
     }
@@ -52,6 +95,14 @@ public class BlockPosition implements com.github.angeschossen.pluginframework.ap
         return coordinate.world.equals(this.world) && coordinate.x == x && coordinate.z == z && coordinate.y == y;
     }
 
+    /**
+     * Checks whether this position's coordinates match the given values, ignoring world.
+     *
+     * @param x the x-coordinate
+     * @param y the y-coordinate
+     * @param z the z-coordinate
+     * @return {@code true} if all three coordinates match
+     */
     public final boolean equals(int x, int y, int z) {
         return this.x == x && this.z == z && this.y == y;
     }
@@ -107,6 +158,11 @@ public class BlockPosition implements com.github.angeschossen.pluginframework.ap
         return world.isChunkLoaded(x >> 4, z >> 4);
     }
 
+    /**
+     * Serializes this position to a JSON object with world, x, y, and z fields.
+     *
+     * @return a JSON representation of this position
+     */
     @NotNull
     public JsonObject toJson() {
         JsonObject jsonObject = new JsonObject();

--- a/src/main/java/com/github/angeschossen/pluginframework/api/blockutil/impl/ChunkCoordinate.java
+++ b/src/main/java/com/github/angeschossen/pluginframework/api/blockutil/impl/ChunkCoordinate.java
@@ -2,10 +2,19 @@ package com.github.angeschossen.pluginframework.api.blockutil.impl;
 
 import java.util.Objects;
 
+/**
+ * Immutable chunk coordinate holding the chunk-level x and z values.
+ */
 public class ChunkCoordinate implements com.github.angeschossen.pluginframework.api.blockutil.ChunkCoordinate {
 
     private final int x, z;
 
+    /**
+     * Creates a new chunk coordinate.
+     *
+     * @param x the chunk x-coordinate
+     * @param z the chunk z-coordinate
+     */
     public ChunkCoordinate(int x, int z) {
         this.x = x;
         this.z = z;

--- a/src/main/java/com/github/angeschossen/pluginframework/api/blockutil/impl/Position.java
+++ b/src/main/java/com/github/angeschossen/pluginframework/api/blockutil/impl/Position.java
@@ -9,11 +9,24 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.Objects;
 
+/**
+ * Immutable position in a loaded world, including precise (double) coordinates, yaw, and pitch.
+ */
 public class Position implements com.github.angeschossen.pluginframework.api.blockutil.Position {
     private final float yaw, pitch;
     private final double x, y, z;
     private final World world;
 
+    /**
+     * Creates a new position with the given world, coordinates, and rotation.
+     *
+     * @param world the world
+     * @param x     the x-coordinate
+     * @param y     the y-coordinate
+     * @param z     the z-coordinate
+     * @param yaw   the yaw rotation
+     * @param pitch the pitch rotation
+     */
     public Position(World world, double x, double y, double z, float yaw, float pitch) {
         this.world = world;
         this.x = x;
@@ -23,14 +36,29 @@ public class Position implements com.github.angeschossen.pluginframework.api.blo
         this.yaw = yaw;
     }
 
+    /**
+     * Returns the pitch rotation of this position.
+     *
+     * @return the pitch
+     */
     public float getPitch() {
         return pitch;
     }
 
+    /**
+     * Returns the yaw rotation of this position.
+     *
+     * @return the yaw
+     */
     public float getYaw() {
         return yaw;
     }
 
+    /**
+     * Creates a new position from the given Bukkit location.
+     *
+     * @param location the location to copy coordinates and rotation from
+     */
     public Position(Location location) {
         this(location.getWorld(), location.getX(), location.getY(), location.getZ(), location.getYaw(), location.getPitch());
     }
@@ -66,6 +94,13 @@ public class Position implements com.github.angeschossen.pluginframework.api.blo
         return z;
     }
 
+    /**
+     * Deserializes a {@code Position} from a JSON object.
+     * Returns {@code null} if the world specified in the JSON is not loaded.
+     *
+     * @param jsonObject the JSON object containing world, x, y, z, yaw, and pitch fields
+     * @return the deserialized position, or {@code null} if the world is not loaded
+     */
     @Nullable
     public static Position fromJson(JsonObject jsonObject) {
         World world = Bukkit.getWorld(jsonObject.get("world").getAsString());
@@ -103,6 +138,11 @@ public class Position implements com.github.angeschossen.pluginframework.api.blo
         return Objects.hash(world, x, y, z, yaw, pitch);
     }
 
+    /**
+     * Serializes this position to a JSON object with world, x, y, z, yaw, and pitch fields.
+     *
+     * @return a JSON representation of this position
+     */
     @NotNull
     public JsonObject toJson() {
         JsonObject jsonObject = new JsonObject();

--- a/src/main/java/com/github/angeschossen/pluginframework/api/blockutil/impl/UnloadedPosition.java
+++ b/src/main/java/com/github/angeschossen/pluginframework/api/blockutil/impl/UnloadedPosition.java
@@ -11,6 +11,10 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.Objects;
 
+/**
+ * Position that may reference a world or server that is not currently loaded.
+ * Coordinates are stored by name so they survive world unloads and server restarts.
+ */
 public class UnloadedPosition implements com.github.angeschossen.pluginframework.api.blockutil.UnloadedPosition {
 
     private final String worldName;
@@ -18,14 +22,40 @@ public class UnloadedPosition implements com.github.angeschossen.pluginframework
     private final float yaw, pitch;
     private final double x, y, z;
 
+    /**
+     * Creates a new unloaded position without rotation (yaw and pitch default to 0).
+     *
+     * @param serverName the name of the target server
+     * @param worldName  the name of the world
+     * @param x          the x-coordinate
+     * @param y          the y-coordinate
+     * @param z          the z-coordinate
+     */
     public UnloadedPosition(String serverName, String worldName, double x, double y, double z) {
         this(serverName, worldName, x, y, z, 0, 0);
     }
 
+    /**
+     * Creates a new unloaded position from a loaded {@link Position}.
+     * The server name is resolved from the current {@link APIHandler} instance.
+     *
+     * @param position the loaded position to convert
+     */
     public UnloadedPosition(Position position) {
         this(APIHandler.getInstance().getServerName(), position.getWorld().getName(), position.getX(), position.getY(), position.getZ(), position.getYaw(), position.getPitch());
     }
 
+    /**
+     * Creates a new unloaded position with all fields explicitly specified.
+     *
+     * @param serverName the name of the target server
+     * @param worldName  the name of the world
+     * @param x          the x-coordinate
+     * @param y          the y-coordinate
+     * @param z          the z-coordinate
+     * @param yaw        the yaw rotation
+     * @param pitch      the pitch rotation
+     */
     public UnloadedPosition(@NotNull String serverName, @NotNull String worldName, double x, double y, double z, float yaw, float pitch) {
         this.x = x;
         this.y = y;
@@ -53,14 +83,36 @@ public class UnloadedPosition implements com.github.angeschossen.pluginframework
         return APIHandler.getInstance().getMultiPaperHandler().isTargetServer(serverName);
     }
 
+    /**
+     * Creates a new unloaded position from a Bukkit {@link Location}.
+     * The server name is resolved from the current {@link APIHandler} instance.
+     *
+     * @param location the location to convert
+     */
     public UnloadedPosition(@NotNull Location location) {
         this(APIHandler.getInstance().getServerName(), location.getWorld().getName(), location.getX(), location.getY(), location.getZ(), location.getYaw(), location.getPitch());
     }
 
+    /**
+     * Deserializes an {@code UnloadedPosition} from a JSON object.
+     *
+     * @param jsonObject the JSON object containing server, world, x, y, z, yaw, and pitch fields
+     * @return the deserialized position
+     */
     public static UnloadedPosition fromJson(@NotNull JsonObject jsonObject) {
         return new UnloadedPosition(jsonObject.has("server") ? jsonObject.get("server").getAsString() : APIHandler.getInstance().getServerName(), jsonObject.get("world").getAsString(), jsonObject.get("x").getAsDouble(), jsonObject.get("y").getAsDouble(), jsonObject.get("z").getAsDouble(), jsonObject.get("yaw").getAsFloat(), jsonObject.get("pitch").getAsFloat());
     }
 
+    /**
+     * Checks whether this position matches the given server name, world, and block coordinates.
+     *
+     * @param serverName the server name to compare
+     * @param world      the world to compare
+     * @param x          the x-coordinate
+     * @param y          the y-coordinate
+     * @param z          the z-coordinate
+     * @return {@code true} if server, world, and all coordinates match
+     */
     public boolean equals(String serverName, World world, int x, int y, int z) {
         if (!serverName.equals(this.serverName) || !world.equals(getWorld())) {
             return false;
@@ -176,6 +228,11 @@ public class UnloadedPosition implements com.github.angeschossen.pluginframework
         return isTargetServer() && worldName.equalsIgnoreCase(this.worldName);
     }
 
+    /**
+     * Serializes this position to a JSON object with server, world, x, y, z, yaw, and pitch fields.
+     *
+     * @return a JSON representation of this position
+     */
     public JsonObject toJsonObject() {
         JsonObject jsonObject = new JsonObject();
         jsonObject.addProperty("server", serverName);

--- a/src/main/java/com/github/angeschossen/pluginframework/api/configuration/Configuration.java
+++ b/src/main/java/com/github/angeschossen/pluginframework/api/configuration/Configuration.java
@@ -5,6 +5,9 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 
+/**
+ * Provides read access to plugin configuration values by key.
+ */
 public interface Configuration {
 
     /**

--- a/src/main/java/com/github/angeschossen/pluginframework/api/events/PluginEvent.java
+++ b/src/main/java/com/github/angeschossen/pluginframework/api/events/PluginEvent.java
@@ -18,6 +18,9 @@ import java.util.UUID;
  */
 public abstract class PluginEvent extends Event {
 
+    /**
+     * Creates a new event, automatically detecting whether it is fired asynchronously.
+     */
     public PluginEvent() {
         super(!Bukkit.isPrimaryThread());
     }

--- a/src/main/java/com/github/angeschossen/pluginframework/api/exceptions/IllegalUntrustException.java
+++ b/src/main/java/com/github/angeschossen/pluginframework/api/exceptions/IllegalUntrustException.java
@@ -6,6 +6,11 @@ package com.github.angeschossen.pluginframework.api.exceptions;
  */
 public class IllegalUntrustException extends RuntimeException {
 
+    /**
+     * Creates a new exception with the given detail message.
+     *
+     * @param errorMessage the detail message
+     */
     public IllegalUntrustException(String errorMessage) {
         super(errorMessage);
     }

--- a/src/main/java/com/github/angeschossen/pluginframework/api/exceptions/NameAlreadyTakenException.java
+++ b/src/main/java/com/github/angeschossen/pluginframework/api/exceptions/NameAlreadyTakenException.java
@@ -5,6 +5,11 @@ package com.github.angeschossen.pluginframework.api.exceptions;
  */
 public class NameAlreadyTakenException extends RuntimeException {
 
+    /**
+     * Creates a new exception with the given detail message.
+     *
+     * @param errorMessage the detail message
+     */
     public NameAlreadyTakenException(String errorMessage) {
         super(errorMessage);
     }

--- a/src/main/java/com/github/angeschossen/pluginframework/api/exceptions/NoAccessException.java
+++ b/src/main/java/com/github/angeschossen/pluginframework/api/exceptions/NoAccessException.java
@@ -5,6 +5,11 @@ package com.github.angeschossen.pluginframework.api.exceptions;
  */
 public class NoAccessException extends RuntimeException {
 
+    /**
+     * Creates a new exception with the given detail message.
+     *
+     * @param errorMessage the detail message
+     */
     public NoAccessException(String errorMessage) {
         super(errorMessage);
     }

--- a/src/main/java/com/github/angeschossen/pluginframework/api/exceptions/OwnerUntrustException.java
+++ b/src/main/java/com/github/angeschossen/pluginframework/api/exceptions/OwnerUntrustException.java
@@ -5,6 +5,11 @@ package com.github.angeschossen.pluginframework.api.exceptions;
  */
 public class OwnerUntrustException extends RuntimeException {
 
+    /**
+     * Creates a new exception with the given detail message.
+     *
+     * @param errorMessage the detail message
+     */
     public OwnerUntrustException(String errorMessage) {
         super(errorMessage);
     }

--- a/src/main/java/com/github/angeschossen/pluginframework/api/exceptions/PlayerTrustedException.java
+++ b/src/main/java/com/github/angeschossen/pluginframework/api/exceptions/PlayerTrustedException.java
@@ -5,6 +5,11 @@ package com.github.angeschossen.pluginframework.api.exceptions;
  */
 public class PlayerTrustedException extends RuntimeException {
 
+    /**
+     * Creates a new exception with the given detail message.
+     *
+     * @param errorMessage the detail message
+     */
     public PlayerTrustedException(String errorMessage) {
         super(errorMessage);
     }

--- a/src/main/java/com/github/angeschossen/pluginframework/api/exceptions/PlayerUntrustedException.java
+++ b/src/main/java/com/github/angeschossen/pluginframework/api/exceptions/PlayerUntrustedException.java
@@ -5,6 +5,11 @@ package com.github.angeschossen.pluginframework.api.exceptions;
  */
 public class PlayerUntrustedException extends RuntimeException {
 
+    /**
+     * Creates a new exception with the given detail message.
+     *
+     * @param errorMessage the detail message
+     */
     public PlayerUntrustedException(String errorMessage) {
         super(errorMessage);
     }

--- a/src/main/java/com/github/angeschossen/pluginframework/api/exceptions/RolePriorityException.java
+++ b/src/main/java/com/github/angeschossen/pluginframework/api/exceptions/RolePriorityException.java
@@ -6,6 +6,11 @@ package com.github.angeschossen.pluginframework.api.exceptions;
  */
 public class RolePriorityException extends RuntimeException {
 
+    /**
+     * Creates a new exception with the given detail message.
+     *
+     * @param errorMessage the detail message
+     */
     public RolePriorityException(String errorMessage) {
         super(errorMessage);
     }

--- a/src/main/java/com/github/angeschossen/pluginframework/api/exceptions/command/InvalidInputException.java
+++ b/src/main/java/com/github/angeschossen/pluginframework/api/exceptions/command/InvalidInputException.java
@@ -5,4 +5,10 @@ package com.github.angeschossen.pluginframework.api.exceptions.command;
  */
 public class InvalidInputException extends Exception {
 
+    /**
+     * Creates a new {@code InvalidInputException} with no detail message.
+     */
+    public InvalidInputException() {
+        super();
+    }
 }

--- a/src/main/java/com/github/angeschossen/pluginframework/api/exceptions/menu/UnhandledItemResponseException.java
+++ b/src/main/java/com/github/angeschossen/pluginframework/api/exceptions/menu/UnhandledItemResponseException.java
@@ -5,6 +5,9 @@ package com.github.angeschossen.pluginframework.api.exceptions.menu;
  */
 public class UnhandledItemResponseException extends RuntimeException {
 
+    /**
+     * Creates a new exception with the default message {@code "Unhandled item response"}.
+     */
     public UnhandledItemResponseException() {
         super("Unhandled item response");
     }

--- a/src/main/java/com/github/angeschossen/pluginframework/api/exceptions/menu/UnhandledMenuTypeException.java
+++ b/src/main/java/com/github/angeschossen/pluginframework/api/exceptions/menu/UnhandledMenuTypeException.java
@@ -5,6 +5,9 @@ package com.github.angeschossen.pluginframework.api.exceptions.menu;
  */
 public class UnhandledMenuTypeException extends RuntimeException {
 
+    /**
+     * Creates a new exception with the default message {@code "Unhandled menu type"}.
+     */
     public UnhandledMenuTypeException() {
         super("Unhandled menu type");
     }

--- a/src/main/java/com/github/angeschossen/pluginframework/api/flags/roles/RoleFlag.java
+++ b/src/main/java/com/github/angeschossen/pluginframework/api/flags/roles/RoleFlag.java
@@ -17,7 +17,9 @@ import org.jetbrains.annotations.Nullable;
  */
 public abstract class RoleFlag {
 
+    /** The plugin that registered this flag. */
     protected final @NotNull Plugin plugin;
+    /** The unique, lowercase name of this flag. */
     protected final @NotNull String name;
 
     /**

--- a/src/main/java/com/github/angeschossen/pluginframework/api/limit/holder/LimitHolder.java
+++ b/src/main/java/com/github/angeschossen/pluginframework/api/limit/holder/LimitHolder.java
@@ -11,7 +11,7 @@ import java.util.concurrent.CompletableFuture;
 
 /**
  * Implemented by objects (typically players or groups) that are subject to {@link Limit}s.
- * The holder's effective limit value is the base value plus any applicable {@link LimitModifier}s.
+ * The holder's effective limit value is the base value plus any applicable {@link com.github.angeschossen.pluginframework.api.limit.LimitModifier}s.
  */
 public interface LimitHolder {
 
@@ -53,14 +53,19 @@ public interface LimitHolder {
     boolean hasLimitPack(@NotNull HolderLimitPack limitPack);
 
     /**
-     * Check if a new limit pack is available and set it.
+     * Checks whether a new limit pack is available for this holder and applies it if so.
      *
+     * @return a future that resolves to the holder's current {@link HolderLimitPack}
      */
     @NotNull
     default CompletableFuture<HolderLimitPack> refreshLimitPack() {
         return CompletableFuture.completedFuture(null);
     }
 
+    /**
+     * Called when this holder's limit pack has changed.
+     * Override to react to pack changes, for example to refresh cached limit values.
+     */
     default void onLimitPackChanged() {
     }
 

--- a/src/main/java/com/github/angeschossen/pluginframework/api/trusted/RoleHolder.java
+++ b/src/main/java/com/github/angeschossen/pluginframework/api/trusted/RoleHolder.java
@@ -124,7 +124,8 @@ public interface RoleHolder {
     /**
      * Untrust a player that is trusted directly to this protection.
      *
-     * @param playerUUID The player to untrust
+     * @param playerUUID the player to untrust
+     * @return {@code true} if the player was untrusted; {@code false} if they were not trusted
      */
     boolean untrustPlayer(@NotNull UUID playerUUID);
 }

--- a/src/main/java/com/github/angeschossen/pluginframework/api/utils/Checks.java
+++ b/src/main/java/com/github/angeschossen/pluginframework/api/utils/Checks.java
@@ -10,6 +10,12 @@ import java.util.Objects;
 public class Checks {
 
     /**
+     * Private constructor — utility class, not instantiable.
+     */
+    private Checks() {
+    }
+
+    /**
      * Ensures the given object is not {@code null}.
      *
      * @param o   the object to check


### PR DESCRIPTION
## Summary

- Add Javadoc comments to all previously undocumented public classes, interfaces, constructors, methods, and fields — resolves all 68 javadoc compiler warnings
- Add `publishJavadocToNexus` Gradle task that extracts the javadoc jar and uploads its contents to the Nexus raw repository at both the versioned and `latest/` paths
- Upgrade Java toolchain from 17 to 21
- Configure Nexus Maven publish repository with automatic snapshot/release URL switching

## Test plan

- [ ] `./gradlew javadoc` produces zero warnings
- [ ] `./gradlew publishJavadocToNexus` uploads successfully to both versioned and `latest/` Nexus paths
- [ ] `./gradlew build` passes without errors