### PR TITLE
Add Javadoc to all public API types and publish improvements

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -134,12 +134,8 @@ publishing {
     repositories {
         maven {
             name = "nexus"
-            val isSnapshot = version.toString().endsWith("-SNAPSHOT")
             url = uri(
-                if (isSnapshot)
-                    "https://nexus.incredibleplugins.com/repository/maven-snapshots/"
-                else
-                    "https://nexus.incredibleplugins.com/repository/plugin-maven-releases/"
+                "https://nexus.incredibleplugins.com/repository/plugin-maven-public/"
             )
             credentials {
                 username = project.findProperty("nexusUsername") as String? ?: System.getenv("NEXUS_USERNAME")

--- a/src/main/java/com/github/angeschossen/pluginframework/api/trusted/group/Group.java
+++ b/src/main/java/com/github/angeschossen/pluginframework/api/trusted/group/Group.java
@@ -3,6 +3,9 @@ package com.github.angeschossen.pluginframework.api.trusted.group;
 import com.github.angeschossen.pluginframework.api.trusted.RoleHolder;
 import org.jetbrains.annotations.NotNull;
 
+/**
+ * Represents a named group of protections that share a common set of trusted players and roles.
+ */
 public interface Group extends RoleHolder {
     /**
      * Check if the group is the default group.


### PR DESCRIPTION
## Summary

- Add Javadoc comments to all public classes, interfaces, and methods across the API
- Fix all Javadoc warnings to ensure clean documentation builds
- Add `publishJavadocToNexus` Gradle task that uploads to both versioned and `latest/` paths
- Simplify Nexus publish URL to use the public repository endpoint

## Test plan

- [ ] Run `./gradlew build` and verify no Javadoc warnings
- [ ] Run `./gradlew publishJavadocToNexus` and verify docs are uploaded to Nexus at both versioned and `latest/` paths
- [ ] Run `./gradlew publish` and verify artifact publishes to the correct Nexus repository